### PR TITLE
Integrate GitHub Issues CMS for blog posts and issue-based RSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ http://localhost:4000
 
 ## Updating Content
 
+### Blog posts (GitHub Issues CMS)
+Create or edit posts directly in GitHub Issues without pushing repo changes:
+
+1. Open a new issue in this repository.
+2. Set the issue title to your post title.
+3. Write the post in markdown in the issue body.
+4. Add the label `blog` (required).
+5. Add any additional labels as tags (for example: `azure`, `databricks`, `pyspark`).
+
+Notes:
+- All issues with the `blog` label are rendered as posts, including open and closed issues.
+- Update the issue body any time to update the post on the website.
+- Open a post directly at `https://abhinavsreesan.github.io/blog/?post=<issue_number>`.
+- RSS for issue-based posts: `https://github.com/abhinavsreesan/abhinavsreesan.github.io/labels/blog.atom`
+
 ### Resume
 Replace the PDF at:
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Push to the default branch and enable GitHub Pages in the repository settings. T
 ## Changelog
 
 <!-- changelog:start -->
+- PR #6: Integrate GitHub Issues as a CMS for blog posts, enabling issue-based RSS feeds and dynamic blog rendering via JavaScript. ([link](https://github.com/abhinavsreesan/abhinavsreesan.github.io/pull/6))
 - PR #5: Add a Copilot-powered workflow and script to automatically update the README changelog for PRs targeting the master branch. ([link](https://github.com/abhinavsreesan/abhinavsreesan.github.io/pull/5))
 - PR #0: Changelog automation initialized. New PR entries will appear here once the workflow runs.
 <!-- changelog:end -->

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -8,6 +8,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 		<meta name="description" content="{{ site.description }}" />
 		<link rel="stylesheet" href="/assets/css/main.css" />
+		<link rel="alternate" type="application/atom+xml" title="Blog Issues Feed" href="https://github.com/abhinavsreesan/abhinavsreesan.github.io/labels/blog.atom" />
 		<link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
 		<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
 		<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
@@ -21,34 +22,39 @@
 				<p>{{ page.description | default: "Short markdown posts on implementation patterns, lessons learned, and practical references." }}</p>
 				<ul class="actions fixed">
 					<li><a href="/" class="button">Back to Portfolio</a></li>
-					<li><a href="/feed.xml" class="button">RSS</a></li>
+					<li><a href="https://github.com/abhinavsreesan/abhinavsreesan.github.io/labels/blog.atom" class="button" target="_blank" rel="noopener">RSS</a></li>
 				</ul>
 			</header>
 			<main class="blog-main">
 				{{ content }}
-				<section class="blog-list">
-					{% for post in site.posts %}
-					<article class="box blog-card">
-						<h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
-						<p class="blog-meta">{{ post.date | date: "%b %d, %Y" }}</p>
-						<p>{{ post.excerpt | strip_html | truncate: 180 }}</p>
-						{% if post.tags and post.tags.size > 0 %}
-						<div class="skill-badges">
-							{% for tag in post.tags %}
-							<span class="skill-badge">{{ tag }}</span>
-							{% endfor %}
-						</div>
-						{% endif %}
-					</article>
-					{% endfor %}
-					{% if site.posts.size == 0 %}
-					<article class="box blog-card">
-						<h2>No posts yet</h2>
-						<p>Add a markdown file in <code>_posts/</code> using the format <code>YYYY-MM-DD-title.md</code>.</p>
-					</article>
-					{% endif %}
+				<article id="issues-loading" class="box blog-card">
+					<h2>Loading posts...</h2>
+					<p>Fetching posts from GitHub Issues.</p>
+				</article>
+
+				<article id="issues-empty" class="box blog-card" style="display: none;">
+					<h2>No posts yet</h2>
+					<p>Create a GitHub issue and add the <code>blog</code> label to publish it here.</p>
+				</article>
+
+				<article id="issues-error" class="box blog-card" style="display: none;">
+					<h2>Could not load posts</h2>
+					<p>GitHub API might be rate-limited right now. Please refresh in a bit.</p>
+				</article>
+
+				<section id="issues-blog-list" class="blog-list" style="display: none;"></section>
+				<section id="issues-blog-post" style="display: none;"></section>
+
+				<section class="blog-list" id="blog-noscript-fallback">
+					<noscript>
+						<article class="box blog-card">
+							<h2>JavaScript required for issue-powered blog</h2>
+							<p>This blog uses GitHub Issues as a CMS and needs JavaScript enabled to render posts.</p>
+						</article>
+					</noscript>
 				</section>
 			</main>
 		</div>
+		<script src="/assets/js/blog-issues.js"></script>
 	</body>
 </html>

--- a/assets/js/blog-issues.js
+++ b/assets/js/blog-issues.js
@@ -1,0 +1,324 @@
+(function () {
+  var owner = "abhinavsreesan";
+  var repo = "abhinavsreesan.github.io";
+  var label = "blog";
+  var perPage = 100;
+  var cacheKey = "blog_issues_cache_v1";
+  var cacheTtlMs = 10 * 60 * 1000;
+  var markdownApi = "https://api.github.com/markdown";
+  var issuesApi =
+    "https://api.github.com/repos/" +
+    owner +
+    "/" +
+    repo +
+    "/issues?state=all&labels=" +
+    encodeURIComponent(label) +
+    "&per_page=" +
+    perPage +
+    "&sort=created&direction=desc";
+
+  var listContainer = document.getElementById("issues-blog-list");
+  var postContainer = document.getElementById("issues-blog-post");
+  var emptyState = document.getElementById("issues-empty");
+  var errorState = document.getElementById("issues-error");
+  var loadingState = document.getElementById("issues-loading");
+
+  if (!listContainer || !postContainer || !loadingState || !emptyState || !errorState) {
+    return;
+  }
+
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  function formatDate(isoDate) {
+    var date = new Date(isoDate);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit"
+    });
+  }
+
+  function getQueryPostNumber() {
+    var params = new URLSearchParams(window.location.search);
+    var post = params.get("post");
+    if (!post) {
+      return null;
+    }
+    var parsed = parseInt(post, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function setVisibility(element, visible) {
+    element.style.display = visible ? "block" : "none";
+  }
+
+  function setLoading(visible) {
+    setVisibility(loadingState, visible);
+  }
+
+  function getCache() {
+    try {
+      var raw = localStorage.getItem(cacheKey);
+      if (!raw) {
+        return null;
+      }
+      var parsed = JSON.parse(raw);
+      if (!parsed.timestamp || !Array.isArray(parsed.data)) {
+        return null;
+      }
+      if (Date.now() - parsed.timestamp > cacheTtlMs) {
+        return null;
+      }
+      return parsed.data;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setCache(data) {
+    try {
+      localStorage.setItem(
+        cacheKey,
+        JSON.stringify({
+          timestamp: Date.now(),
+          data: data
+        })
+      );
+    } catch (error) {
+      return;
+    }
+  }
+
+  function normalizeIssues(items) {
+    return items.filter(function (item) {
+      return item && !item.pull_request;
+    });
+  }
+
+  function stripMarkdown(text) {
+    return text
+      .replace(/```[\s\S]*?```/g, "")
+      .replace(/`([^`]+)`/g, "$1")
+      .replace(/!\[[^\]]*\]\([^\)]*\)/g, "")
+      .replace(/\[([^\]]+)\]\([^\)]*\)/g, "$1")
+      .replace(/^#+\s+/gm, "")
+      .replace(/[>*_~\-]{1,3}/g, "")
+      .replace(/\n{2,}/g, "\n")
+      .trim();
+  }
+
+  function toExcerpt(markdown, limit) {
+    if (!markdown) {
+      return "No preview text available.";
+    }
+    var plain = stripMarkdown(markdown).replace(/\n/g, " ").trim();
+    if (plain.length <= limit) {
+      return plain;
+    }
+    return plain.slice(0, limit).replace(/\s+\S*$/, "") + "...";
+  }
+
+  function getTags(labelsArray) {
+    return labelsArray
+      .map(function (item) {
+        return item.name;
+      })
+      .filter(function (name) {
+        return name.toLowerCase() !== label;
+      });
+  }
+
+  function renderTags(tags) {
+    if (!tags.length) {
+      return "";
+    }
+    var tagHtml = tags
+      .map(function (tag) {
+        return '<span class="skill-badge">' + escapeHtml(tag) + "</span>";
+      })
+      .join("");
+    return '<div class="skill-badges">' + tagHtml + "</div>";
+  }
+
+  function renderList(issues) {
+    var cards = issues
+      .map(function (issue) {
+        var excerpt = toExcerpt(issue.body || "", 180);
+        var tags = getTags(issue.labels || []);
+        return (
+          '<article class="box blog-card">' +
+          '<h2><a href="?post=' +
+          issue.number +
+          '">' +
+          escapeHtml(issue.title) +
+          "</a></h2>" +
+          '<p class="blog-meta">' +
+          formatDate(issue.created_at) +
+          "</p>" +
+          "<p>" +
+          escapeHtml(excerpt) +
+          "</p>" +
+          renderTags(tags) +
+          "</article>"
+        );
+      })
+      .join("");
+
+    listContainer.innerHTML = cards;
+    setVisibility(listContainer, true);
+    setVisibility(postContainer, false);
+    setVisibility(emptyState, false);
+    setVisibility(errorState, false);
+  }
+
+  function renderMarkdown(markdown) {
+    return fetch(markdownApi, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/vnd.github+json"
+      },
+      body: JSON.stringify({
+        text: markdown,
+        mode: "gfm",
+        context: owner + "/" + repo
+      })
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error("Could not render markdown");
+      }
+      return response.text();
+    });
+  }
+
+  function renderPost(issue) {
+    var tags = getTags(issue.labels || []);
+    var headerHtml =
+      '<article class="box blog-card blog-post">' +
+      "<h2>" +
+      escapeHtml(issue.title) +
+      "</h2>" +
+      '<p class="blog-meta">' +
+      formatDate(issue.created_at) +
+      "</p>";
+    var footerHtml =
+      '<p><a href="' +
+      issue.html_url +
+      '" target="_blank" rel="noopener">View source issue on GitHub</a></p>' +
+      renderTags(tags) +
+      "</article>";
+
+    renderMarkdown(issue.body || "")
+      .then(function (contentHtml) {
+        postContainer.innerHTML = headerHtml + contentHtml + footerHtml;
+      })
+      .catch(function () {
+        postContainer.innerHTML =
+          headerHtml +
+          "<p>" +
+          escapeHtml(issue.body || "")
+            .replace(/\n\n/g, "</p><p>")
+            .replace(/\n/g, "<br />") +
+          "</p>" +
+          footerHtml;
+      });
+
+    setVisibility(listContainer, false);
+    setVisibility(postContainer, true);
+    setVisibility(emptyState, false);
+    setVisibility(errorState, false);
+  }
+
+  function renderEmpty() {
+    setVisibility(listContainer, false);
+    setVisibility(postContainer, false);
+    setVisibility(emptyState, true);
+    setVisibility(errorState, false);
+  }
+
+  function renderError() {
+    setVisibility(listContainer, false);
+    setVisibility(postContainer, false);
+    setVisibility(emptyState, false);
+    setVisibility(errorState, true);
+  }
+
+  function fetchIssues() {
+    return fetch(issuesApi, {
+      headers: {
+        Accept: "application/vnd.github+json"
+      }
+    }).then(function (response) {
+      if (!response.ok) {
+        throw new Error("Failed to fetch issues");
+      }
+      return response.json();
+    });
+  }
+
+  function start() {
+    setLoading(true);
+
+    var queryPost = getQueryPostNumber();
+    var cached = getCache();
+    if (cached) {
+      var cachedIssues = normalizeIssues(cached);
+      if (cachedIssues.length > 0) {
+        if (queryPost) {
+          var cachedPost = cachedIssues.find(function (item) {
+            return item.number === queryPost;
+          });
+          if (cachedPost) {
+            renderPost(cachedPost);
+          } else {
+            renderEmpty();
+          }
+        } else {
+          renderList(cachedIssues);
+        }
+      }
+    }
+
+    fetchIssues()
+      .then(function (items) {
+        var issues = normalizeIssues(items);
+        setCache(issues);
+
+        if (!issues.length) {
+          renderEmpty();
+          return;
+        }
+
+        if (queryPost) {
+          var post = issues.find(function (item) {
+            return item.number === queryPost;
+          });
+          if (!post) {
+            renderEmpty();
+            return;
+          }
+          renderPost(post);
+          return;
+        }
+
+        renderList(issues);
+      })
+      .catch(function () {
+        if (!cached) {
+          renderError();
+        }
+      })
+      .finally(function () {
+        setLoading(false);
+      });
+  }
+
+  start();
+})();


### PR DESCRIPTION
## Summary
- Replaces static Jekyll post listing on the blog page with a client-side GitHub Issues integration.
- Adds an issues-powered renderer that fetches all issues labeled `blog` (`state=all`), filters out PRs, and supports post detail routes via `?post=<issue_number>`.
- Updates blog RSS links to the label feed and documents the new no-commit publishing workflow in the README.
## Why
Publishing blog content through `_posts` required repository changes for every post. This update enables issue-driven publishing directly from GitHub, making blog updates faster and easier without code commits.
## Changes Included
- Added `assets/js/blog-issues.js`:
  - fetches issues from GitHub API
  - renders post cards and full post view
  - maps labels (excluding `blog`) to tags
  - includes loading/empty/error states
  - adds lightweight local cache for resilience
- Updated `_layouts/blog.html`:
  - switched blog content containers to dynamic issue-rendered sections
  - added JavaScript-powered and noscript fallback blocks
  - updated RSS button and feed discovery to:
    - `https://github.com/abhinavsreesan/abhinavsreesan.github.io/labels/blog.atom`
- Updated `README.md`:
  - added “Blog posts (GitHub Issues CMS)” instructions
  - documented publish/edit flow and direct post URL format
## Validation
- `/blog/` shows issue-based post cards.
- `/blog/?post=<issue_number>` opens a specific post.
- RSS button opens the `blog` label Atom feed.